### PR TITLE
🔧 sub-api deploy

### DIFF
--- a/.github/workflows/publish.sub-api.yml
+++ b/.github/workflows/publish.sub-api.yml
@@ -1,19 +1,19 @@
 name: publish
 on:
-  pull_request:
+  push:
     branches:
       - main
       - master
-
+    paths:
+      - 'sub-api/**'
 jobs:
   publish:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - run: npm install
       - run: npm test
       - uses: JS-DevTools/npm-publish@v1


### PR DESCRIPTION
.github workflow sould be at root ref [Doc](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#about-yaml-syntax-for-workflows)