### PR TITLE
fix: use Promise.any instead

### DIFF
--- a/minipfs/src/race.ts
+++ b/minipfs/src/race.ts
@@ -19,5 +19,5 @@ export function competition<T>(
     .map<HTTPS_URI>(provider => `${provider}${path}`)
     .map(uri => callback(uri))
 
-  return Promise.race(urls)
+  return Promise.any(urls)
 }


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot NFT gallery](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Chore

### What's new?

when I was debugging `snek`, I found so many errors regarding `FetchError: 429 Too Many Requests (https://nftstorage.link/ipfs/bafkreieluki3iafzhyzrd7jfcyw4xid2u3rci75foct5symsrsievgd5mm)`. `Promise.race` will find the faster result even if the Promise is rejected. It would be better if we use `Promise.any` instead. For detailed comparison: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/race#comparison_with_promise.any

<img width="1624" alt="Screenshot 2022-10-28 at 17 39 46" src="https://user-images.githubusercontent.com/734428/198568577-308e8cba-4d12-4ebe-9900-708cc359d604.png">


### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [ ] I've posted a screenshot of demonstrated change in this PR
- [ ] I've written some unit tests 🧪

### Optional

- [ ] I found edge cases

### Had issue bounty label?

- [ ] Fill up your KSM address: [Payout](https://beta.kodadot.xyz/transfer/?target=<My_Kusama_Address_check_https://github.com/kodadot/nft-gallery/blob/main/CONTRIBUTING.md#creating-your-ksm-address>)

### Community participation

- [x] [Are you at KodaDot Discord?](https://discord.gg/35hzy2dXXh)
